### PR TITLE
posix: implement CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.15)
+project(st_device_sdk_c C)
+
+set(CMAKE_C_STANDARD 99)
+
+set(CJSON_DIR src/deps/json)
+set(LIBSODIUM_DIR src/deps/libsodium)
+set(MBEDTLS_DIR src/deps/mbedtls)
+set(CURL_DIR src/deps/curl)
+
+include(CheckIncludeFileCXX)
+check_include_file_cxx(${CJSON_DIR}/cJSON/cJSON.h CJSON_H)
+if (NOT CJSON_H)
+    message(STATUS "submodule init for cJSON")
+    execute_process(COMMAND git submodule update --init ${CJSON_DIR}
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endif (NOT CJSON_H)
+
+check_include_file_cxx(${LIBSODIUM_DIR}/libsodium/src/libsodium/include/sodium.h LIBSODIUM_H)
+if (NOT LIBSODIUM_H)
+    message(STATUS "submodule init for libsodium")
+    execute_process(COMMAND git submodule update --init ${LIBSODIUM_DIR}
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endif (NOT LIBSODIUM_H)
+
+check_include_file_cxx(${MBEDTLS_DIR}/mbedtls/include/ssl.h MBEDTLS_H)
+if (NOT MBEDTLS_H)
+    message(STATUS "submodule init for mbedtls")
+    execute_process(COMMAND git submodule update --init ${MBEDTLS_DIR}
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endif (NOT MBEDTLS_H)
+
+check_include_file_cxx(${CURL_DIR}/curl/include/curl/curl.h CURL_H)
+if (NOT CURL_H)
+    message(STATUS "submodule init for curl")
+    execute_process(COMMAND git submodule update --init ${CURL_DIR}
+            WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}")
+endif (NOT CURL_H)
+
+add_library(iotcore "")
+add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,37 @@
+target_include_directories(iotcore
+        PUBLIC
+        deps/libsodium/libsodium/src/libsodium/include
+        deps/libsodium/libsodium/src/libsodium/include/sodium
+        deps/libsodium/port/include
+        deps/curl/curl/include
+        deps/curl/curl/include/curl
+        deps/json/cJSON
+        deps/mbedtls/mbedtls/include
+        port/net/mbedtls
+        include
+        include/bsp
+        include/bsp/posix
+        include/os
+        include/mqtt
+        )
+add_subdirectory(port/bsp/posix)
+add_subdirectory(port/os/posix)
+add_subdirectory(deps/json)
+add_subdirectory(easysetup)
+add_subdirectory(mqtt)
+add_subdirectory(crypto)
+add_subdirectory(deps/curl/curl)
+add_subdirectory(deps/libsodium)
+
+target_sources(iotcore
+        PRIVATE
+        iot_api.c
+        iot_crypto.c
+        iot_capability.c
+        iot_jwt.c
+        iot_main.c
+        iot_mqtt.c
+        iot_nv_data.c
+        iot_util.c
+        iot_uuid.c
+        )

--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(iotcore
+        PRIVATE
+        iot_crypto_ed25519.c
+        mbedtls/iot_crypto_mbedtls.c
+        ss/iot_crypto_ss.c
+        )

--- a/src/deps/json/CMakeLists.txt
+++ b/src/deps/json/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(iotcore
+        PRIVATE
+        cJSON/cJSON.c
+        )

--- a/src/deps/libsodium/CMakeLists.txt
+++ b/src/deps/libsodium/CMakeLists.txt
@@ -1,0 +1,5 @@
+aux_source_directory(libsodium LIBSODIUM_SRC)
+target_sources(iotcore
+        PRIVATE
+        ${LIBSODIUM_SRC}
+        )

--- a/src/easysetup/CMakeLists.txt
+++ b/src/easysetup/CMakeLists.txt
@@ -1,0 +1,6 @@
+target_sources(iotcore
+        PRIVATE
+        iot_easysetup_crypto.c
+        iot_easysetup_st_mqtt.c
+        posix_testing/iot_easysetup_posix_testing.c
+        )

--- a/src/mqtt/CMakeLists.txt
+++ b/src/mqtt/CMakeLists.txt
@@ -1,0 +1,14 @@
+target_sources(iotcore
+        PRIVATE
+        client/iot_mqtt_client.c
+        packet/iot_mqtt_connect_client.c
+        packet/iot_mqtt_connect_server.c
+        packet/iot_mqtt_deserialize_publish.c
+        packet/iot_mqtt_format.c
+        packet/iot_mqtt_packet.c
+        packet/iot_mqtt_serialize_publish.c
+        packet/iot_mqtt_subscribe_client.c
+        packet/iot_mqtt_subscribe_server.c
+        packet/iot_mqtt_unsubscribe_client.c
+        packet/iot_mqtt_unsubscribe_server.c
+        )

--- a/src/port/bsp/posix/CMakeLists.txt
+++ b/src/port/bsp/posix/CMakeLists.txt
@@ -1,0 +1,9 @@
+target_sources(iotcore
+        PRIVATE
+        iot_bsp_debug_posix.c
+        iot_bsp_fs_posix.c
+        iot_bsp_nv_data_posix.c
+        iot_bsp_random_posix.c
+        iot_bsp_system_posix.c
+        iot_bsp_wifi_posix.c
+        )

--- a/src/port/os/posix/CMakeLists.txt
+++ b/src/port/os/posix/CMakeLists.txt
@@ -1,0 +1,4 @@
+target_sources(iotcore
+        PRIVATE
+        iot_os_util_posix.c
+        )


### PR DESCRIPTION
Because st-device-sdk doesn't have CMakeLists.txt, it is hard to use CMake based IDE (e.g. CLion).
this changes is only for IDE interaction for now. I didn't validate it's build output