### PR TITLE
No need to store generated keys in git. Added output folders to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ src/deps/lwip/lwip/
 src/deps/mbedtls/mbedtls/
 tools/keygen/linux/ed25519*
 tools/keygen/linux/output_*
+tools/keygen/output_*
 doc/doxygen/
 build/
 output/


### PR DESCRIPTION
Simply added default location of generated keys to .gitignore so they won't show up as changes